### PR TITLE
F -> _F

### DIFF
--- a/include/arduino-mock/Arduino.h
+++ b/include/arduino-mock/Arduino.h
@@ -74,7 +74,7 @@ void loop(void);
 #include <gmock/gmock.h>
 
 #define UNUSED(expr) do { (void)(expr); } while (0)
-#define F(x) (x)
+#define _F(x) (x)
 
 class ArduinoMock {
   public:


### PR DESCRIPTION
rename macro `F` in Arduino.h to `_F` to avoid a clash with another macro with the same name