### PR TITLE
Fix macOS (AppleClang) incompatibilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 2.8.8)
 project (arduino_mock)
 
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "Set the C++ standard to be used for compiling")
+
 find_package(Threads REQUIRED)
 add_subdirectory(lib/gtest)
 

--- a/include/arduino-mock/Arduino.h
+++ b/include/arduino-mock/Arduino.h
@@ -19,6 +19,7 @@ extern "C" {
 
 #ifdef WIN32
 #elif linux
+#elif __APPLE__
 #else
 #define true 0x1
 #define false 0x0

--- a/src/Serial.cc
+++ b/src/Serial.cc
@@ -1,5 +1,6 @@
 // Copyright 2014 http://switchdevice.com
 
+#include <iomanip>
 #include "arduino-mock/Serial.h"
 
 static SerialMock* gSerialMock = NULL;


### PR DESCRIPTION
These minor changes were required to get `arduino-mock` to build on macOS.